### PR TITLE
Use `yaml.safe_load_all()`

### DIFF
--- a/panopy/pano.py
+++ b/panopy/pano.py
@@ -105,7 +105,7 @@ def main():
 
     # load all templates, and merge together
     with open(os.path.expanduser(os.path.join(DEFAULT_PATH))) as fin:
-        templates = yaml.load_all(fin)
+        templates = yaml.safe_load_all(fin)
         all_templates = dict()
         for x in templates:
             if x is not None:


### PR DESCRIPTION
Since PyYAML 5.1, it emits a deprecation warning when using `load_all()` without explicitly specifying a loader. Using `safe_load_all()` prevents this (and should be safer).